### PR TITLE
Red Flag 8/9 완화책 예시 추가: 독립 검증 레이어 (invinoveritas /review)

### DIFF
--- a/Awesome Vibe Trading Bot.MD
+++ b/Awesome Vibe Trading Bot.MD
@@ -793,6 +793,37 @@ LLM 트레이딩 봇 중 상당수는 **하나의 LLM 호출 결과를 그대로
 - LLM 신호 + 전통적 기술적 지표의 AND 조건 적용
 - "LLM이 판단을 보류할 수 있는" null hypothesis 설계 (매매하지 않는 것을 기본값으로)
 
+**참고: "교차검증"을 별도 서비스로 구현한 예 — invinoveritas**
+
+위 "최소 2개 이상 LLM의 교차검증" 완화책을 트레이딩 봇이 아니라 **독립된 검증 레이어**로 구현한 사례가 있습니다: [invinoveritas](https://api.babyblueviper.com) `/review` 엔드포인트.
+
+트레이딩 봇이 아니고, 시그널을 생성하지도 않습니다. 봇이 만든 제안(진입 방향, 레버리지, 포지션 크기)을 입력으로 받아 **approve / approve_with_concerns / reject** 판정과 서명된 증명(proof)을 반환하는 역할만 합니다. 다루는 범위도 Red Flag 8·9가 겨냥하는 지점(레버리지/포지션 사이징 리스크, 단일 LLM 과신)으로 좁게 한정됩니다.
+
+Red Flag 8의 "실제 위험 시나리오" (LLM 90% confidence Long 신호 → 사용자 10x 레버리지 진입 → 5% 역방향 변동으로 청산)를 그대로 재현해 실제로 호출한 결과입니다:
+
+```json
+{
+  "verdict": "reject",
+  "confidence": 0.95,
+  "summary": "The proposed trade is excessively risky due to high leverage and
+              position size relative to account equity, posing a significant
+              threat to the account's capital.",
+  "issues": [
+    {"severity": "blocker", "category": "position_sizing",
+     "description": "10x leverage on a $2000 position (20% of $10000 account)
+                     is excessively risky.",
+     "suggested_fix": "Reduce leverage to 2x-3x and/or decrease position size
+                       to 5-10% of account equity."},
+    {"severity": "high", "category": "drawdown_risk",
+     "description": "A 10% adverse move could result in a 100% loss of the
+                     position due to 10x leverage, potentially leading to a
+                     margin call or account liquidation."}
+  ]
+}
+```
+
+**정직하게 밝히는 한계**: 응답에는 서명된 증명(`proof`)이 함께 오며, 누구나 `/verify-proof` (무료, 인증 불필요)로 서명을 직접 검증할 수 있습니다 — "믿지 말고 검증하라"는 이 문서의 기조와 같은 방향입니다. 다만 이 증명은 "이 호출이 실제로 일어났고 판정 내용이 변조되지 않았다"만 증명하지, **"이 판정이 그 거래 이전에 실제로 사용되었는지"까지는 증명하지 못합니다** (`vantage_limitation` 필드에 명시된 대로) — 되돌릴 수 없는 실거래 의사결정의 유일한 근거로 삼기보다는, 위 완화책(다중 LLM 교차검증, AND 조건)과 나란히 두는 보조 장치로 보는 것이 정확합니다. 유료 서비스(reject 판정 1회 200 sats ≈ $0.15)이며, invinoveritas 팀이 직접 작성한 항목입니다.
+
 ### Red Flag 10: 온체인/DeFi 통합 시 추가 위험
 
 LLM 트레이딩 봇이 DEX, DeFi Protocol과 연동될 때 발생하는 추가 리스크.


### PR DESCRIPTION
## 요약

**Red Flag 9 ("단일 LLM 판단에 대한 과신") 섹션 끝, Red Flag 10 앞에** 짧은 참고 항목 추가. 기존 완화책 중 "최소 2개 이상 LLM의 교차검증"을 별도 서비스(트레이딩 봇 아님)로 구현한 사례를 소개합니다.

## 왜 이 위치인가

Red Flag 8(레버리지/포지션 사이징)과 Red Flag 9(단일 LLM 과신)가 정확히 겨냥하는 두 가지 문제 — "LLM confidence는 실제 리스크와 무관", "최소 2개 이상 LLM의 교차검증 필요" — 를 구현한 사례라서 이 두 섹션 사이가 자연스러운 위치라고 판단했습니다. 카테고리 A/B 비교 표(트레이딩 봇)에는 넣지 않았습니다 — 시그널을 생성하지 않고 트레이딩 봇도 아니므로 같은 기준으로 비교할 대상이 아니라고 봤습니다.

## 무엇을 넣었는가

- 짧은 설명 (트레이딩 봇 아님, 시그널 생성 안 함, approve/approve_with_concerns/reject 판정만)
- **Red Flag 8의 "실제 위험 시나리오"를 그대로 재현한 실제 호출 결과** (LLM 90% confidence Long 신호 → 10x 레버리지 → reject 판정, 실제 API 응답)
- **정직하게 밝히는 한계** — 서명된 증명(`/verify-proof`, 무료)이 "호출이 실제로 일어났음"은 증명하지만 "거래 이전에 사용되었음"까지는 증명하지 못한다는 점 (`vantage_limitation` 필드에 명시), 유료 서비스라는 점, 다중 LLM 교차검증·AND 조건과 나란히 두는 보조 장치라는 점

## 공개해야 할 것

이 항목은 제가(invinoveritas 팀) 직접 작성했습니다 — 제3자 추천이 아닙니다. 문서의 다른 항목들처럼 강점/약점을 균형 있게 서술하려 했으나, 최종 판단은 메인테이너님께 맡깁니다. 배치·톤·포함 여부 모두 편하게 조정/거절해 주세요.

## 체크리스트

- [x] 기존 Red Flag 1-10 구조·번호 유지 (변경 없음)
- [x] 다른 섹션(비교 표, 한국 거주자 관점, 결론)은 건드리지 않음
- [x] 실제 라이브 API 호출 결과 (합성 데이터 아님, 실제 서명된 응답)
- [x] 한계를 명시 (증명이 증명하지 "못하는" 것까지 포함)
- [x] GitHub 미리보기에서 마크다운 정상 렌더 확인